### PR TITLE
Make import specific

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - deutschland
+    - deutschland.bundesrat
   commands:
     - pip check
   requires:


### PR DESCRIPTION
I'm working on the [conda-forge PyPI mapping](https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/pypi_name_mapping.py). One of the data sources is the import field. Ideally, each package should have a unique import name. The BundesAPI usage of the `deutschland` namespace combines with the lack of specificity in the import name to lead to all the BundesAPI packages being associated to only `deutschland`. Let's see if we can fix that...

Note: I don't want to rebuild, so I don't bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
